### PR TITLE
Texture and UV leaking fixes

### DIFF
--- a/src/main/resources/assets/betterblockentities/models/block/templates/bed_foot_template.json
+++ b/src/main/resources/assets/betterblockentities/models/block/templates/bed_foot_template.json
@@ -12,7 +12,7 @@
       "rotation": {"angle": 0, "axis": "y", "origin": [0, 3, 16]},
       "faces": {
         "east": {"uv": [5.5, 7, 7, 11], "rotation": 90, "texture": "#bed", "cullface": "east"},
-        "south": {"uv": [9.5, 5.5, 5.5, 7], "rotation": 180, "texture": "#bed", "cullface": "south"},
+        "south": {"uv": [5.501, 5.51, 9.499, 7], "rotation": 180, "texture": "#bed", "cullface": "south"},
         "west": {"uv": [0, 7, 1.5, 11], "rotation": 270, "texture": "#bed", "cullface": "west"},
         "up": {"uv": [1.5, 7, 5.5, 11], "texture": "#bed"},
         "down": {"uv": [7, 7, 11, 11], "rotation": 180, "texture": "#bed"}
@@ -25,7 +25,7 @@
       "faces": {
         "north": {"uv": [14, 3.75, 14.75, 4.5], "texture": "#bed"},
         "east": {"uv": [13.25, 3.75, 14, 4.5], "texture": "#bed", "cullface": "east"},
-        "south": {"uv": [12.5, 3.75, 13.25, 4.5], "texture": "#bed", "cullface": "south"},
+        "south": {"uv": [12.5, 3.77, 13.25, 4.5], "texture": "#bed", "cullface": "south"},
         "west": {"uv": [14.75, 3.75, 15.5, 4.5], "texture": "#bed"},
         "down": {"uv": [14, 3, 14.75, 3.75], "rotation": 90, "texture": "#bed", "cullface": "down"}
       }
@@ -37,7 +37,7 @@
       "faces": {
         "north": {"uv": [14.75, 0.75, 15.5, 1.5], "texture": "#bed"},
         "east": {"uv": [14, 0.75, 14.75, 1.5], "texture": "#bed"},
-        "south": {"uv": [13.25, 0.75, 14, 1.5], "texture": "#bed", "cullface": "south"},
+        "south": {"uv": [13.25, 0.77, 14, 1.5], "texture": "#bed", "cullface": "south"},
         "west": {"uv": [12.5, 0.75, 13.25, 1.5], "texture": "#bed", "cullface": "west"},
         "down": {"uv": [14, 0, 14.75, 0.75], "texture": "#bed", "cullface": "down"}
       }

--- a/src/main/resources/assets/betterblockentities/models/block/templates/bed_head_template.json
+++ b/src/main/resources/assets/betterblockentities/models/block/templates/bed_head_template.json
@@ -22,7 +22,7 @@
       "from": [13, 0, 0],
       "to": [16, 3, 3],
       "faces": {
-        "north": {"uv": [13.25, 5.25, 14, 6], "texture": "#bed", "cullface": "north"},
+        "north": {"uv": [13.25, 5.27, 14, 6], "texture": "#bed", "cullface": "north"},
         "east": {"uv": [12.5, 5.25, 13.25, 6], "texture": "#bed", "cullface": "east"},
         "south": {"uv": [14.75, 5.25, 15.5, 6], "texture": "#bed"},
         "west": {"uv": [14, 5.25, 14.75, 6], "texture": "#bed"},
@@ -34,7 +34,7 @@
       "to": [3, 3, 3],
       "rotation": {"angle": 0, "axis": "y", "origin": [1.5, 0, 1.5]},
       "faces": {
-        "north": {"uv": [12.5, 2.25, 13.25, 3], "texture": "#bed", "cullface": "north"},
+        "north": {"uv": [12.5, 2.27, 13.25, 3], "texture": "#bed", "cullface": "north"},
         "east": {"uv": [14.75, 2.25, 15.5, 3], "texture": "#bed"},
         "south": {"uv": [14, 2.25, 14.75, 3], "texture": "#bed"},
         "west": {"uv": [13.25, 2.25, 14, 3], "texture": "#bed", "cullface": "west"},

--- a/src/main/resources/assets/betterblockentities/models/block/templates/chest_lid_template.json
+++ b/src/main/resources/assets/betterblockentities/models/block/templates/chest_lid_template.json
@@ -26,7 +26,6 @@
       "faces": {
         "north": {"uv": [1, 0.25, 1.5, 1.25], "rotation": 180, "texture": "#chest"},
         "east": {"uv": [0, 0.25, 0.25, 1.25], "rotation": 180, "texture": "#chest"},
-        "south": {"uv": [0.25, 0.25, 0.75, 1.25], "rotation": 180, "texture": "#chest"},
         "west": {"uv": [0.75, 0.25, 1, 1.25], "rotation": 180, "texture": "#chest"},
         "up": {"uv": [1.25, 0, 0.75, 0.25], "texture": "#chest"},
         "down": {"uv": [0.25, 0, 0.75, 0.25], "rotation": 180, "texture": "#chest"}

--- a/src/main/resources/assets/betterblockentities/models/block/templates/left_chest_lid_template.json
+++ b/src/main/resources/assets/betterblockentities/models/block/templates/left_chest_lid_template.json
@@ -3,19 +3,18 @@
   "texture_size": [64, 64],
   "textures": {
     "particle": "#chest",
-    "chest": "minecraft:entity/chest/normal"
+    "chest": "minecraft:entity/chest/normal_left"
   },
   "elements": [
     {
       "from": [1, 9, 1],
-      "to": [16, 14, 15],
+      "to": [16, 14, 15.0001],
       "rotation": {"angle": 0, "axis": "y", "origin": [9, 17, 9]},
       "faces": {
         "north": {"uv": [10.75, 3.5, 14.5, 4.75], "rotation": 180, "texture": "#chest"},
         "south": {"uv": [3.5, 3.5, 7.25, 4.75], "rotation": 180, "texture": "#chest"},
         "west": {"uv": [7.25, 3.5, 10.75, 4.75], "rotation": 180, "texture": "#chest"},
-        "up": {"uv": [11, 0, 7.25, 3.5], "texture": "#chest"},
-        "down": {"uv": [7.25, 0, 3.5, 3.5], "texture": "#chest"}
+        "up": {"uv": [11, 0, 7.27, 3.5], "texture": "#chest"}
       }
     },
     {
@@ -24,10 +23,9 @@
       "rotation": {"angle": 0, "axis": "y", "origin": [23, 15, 8]},
       "faces": {
         "north": {"uv": [0.75, 0.25, 1, 1.25], "rotation": 180, "texture": "#chest"},
-        "south": {"uv": [0.25, 0.25, 0.5, 1.25], "texture": "#chest"},
-        "west": {"uv": [0.5, 0.25, 0.75, 1.25], "rotation": 180, "texture": "#chest"},
-        "up": {"uv": [0.5, 0, 0.75, 0.25], "texture": "#chest"},
-        "down": {"uv": [0.25, 0, 0.5, 0.25], "texture": "#chest"}
+        "west": {"uv": [0.75, 0.25, 1, 1.25], "rotation": 180, "texture": "#chest"},
+        "up": {"uv": [0.75, 0, 0.25, 0.25], "texture": "#chest"},
+        "down": {"uv": [0.25, 0, 0.75, 0.25], "rotation": 180, "texture": "#chest"}
       }
     }
   ]

--- a/src/main/resources/assets/betterblockentities/models/block/templates/left_chest_template.json
+++ b/src/main/resources/assets/betterblockentities/models/block/templates/left_chest_template.json
@@ -8,14 +8,14 @@
   "elements": [
     {
       "from": [1, 0, 1],
-      "to": [16, 10, 15],
+      "to": [16, 10, 14.9999],
       "rotation": {"angle": 0, "axis": "y", "origin": [9, 8, 9]},
       "faces": {
         "north": {"uv": [10.75, 8.25, 14.5, 10.75], "rotation": 180, "texture": "#chest"},
         "south": {"uv": [3.5, 8.25, 7.25, 10.75], "rotation": 180, "texture": "#chest"},
         "west": {"uv": [7.25, 8.25, 10.75, 10.75], "rotation": 180, "texture": "#chest"},
         "up": {"uv": [11, 4.75, 7.25, 8.25], "texture": "#chest"},
-        "down": {"uv": [7.25, 4.75, 3.5, 8.25], "texture": "#chest", "cullface": "down"}
+        "down": {"uv": [7.25, 8.25, 3.53, 4.75], "texture": "#chest", "cullface": "down"}
       }
     }
   ]

--- a/src/main/resources/assets/betterblockentities/models/block/templates/right_chest_lid_template.json
+++ b/src/main/resources/assets/betterblockentities/models/block/templates/right_chest_lid_template.json
@@ -3,19 +3,18 @@
   "texture_size": [64, 64],
   "textures": {
     "particle": "#chest",
-    "chest": "minecraft:entity/chest/normal_left"
+    "chest": "minecraft:entity/chest/normal_right"
   },
   "elements": [
     {
-      "from": [0, 9, 1],
-      "to": [15, 14, 15],
+      "from": [0.0001, 9, 1],
+      "to": [15.0002, 14, 15.0001],
       "rotation": {"angle": 0, "axis": "y", "origin": [8, 17, 9]},
       "faces": {
-        "north": {"uv": [10.75, 3.5, 14.5, 4.75], "rotation": 180, "texture": "#chest"},
+        "north": {"uv": [10.77, 3.5, 14.5, 4.75], "rotation": 180, "texture": "#chest"},
         "east": {"uv": [0, 3.5, 3.5, 4.75], "rotation": 180, "texture": "#chest"},
-        "south": {"uv": [3.5, 3.5, 7.25, 4.75], "rotation": 180, "texture": "#chest"},
-        "up": {"uv": [11, 0, 7.25, 3.5], "texture": "#chest"},
-        "down": {"uv": [7.25, 0, 3.5, 3.5], "texture": "#chest"}
+        "south": {"uv": [3.5, 3.5, 7.24, 4.75], "rotation": 180, "texture": "#chest"},
+        "up": {"uv": [10.98, 0, 7.26, 3.5], "texture": "#chest"}
       }
     },
     {
@@ -25,9 +24,8 @@
       "faces": {
         "north": {"uv": [0.75, 0.25, 1, 1.25], "rotation": 180, "texture": "#chest"},
         "east": {"uv": [0, 0.25, 0.25, 1.25], "rotation": 180, "texture": "#chest"},
-        "south": {"uv": [0.25, 0.25, 0.5, 1.25], "texture": "#chest"},
-        "up": {"uv": [0.5, 0, 0.75, 0.25], "texture": "#chest"},
-        "down": {"uv": [0.25, 0, 0.5, 0.25], "texture": "#chest"}
+        "up": {"uv": [0.75, 0, 0.25, 0.25], "texture": "#chest"},
+        "down": {"uv": [0.25, 0, 0.75, 0.25], "rotation": 180, "texture": "#chest"}
       }
     }
   ]

--- a/src/main/resources/assets/betterblockentities/models/block/templates/right_chest_template.json
+++ b/src/main/resources/assets/betterblockentities/models/block/templates/right_chest_template.json
@@ -8,14 +8,14 @@
   "elements": [
     {
       "from": [0, 0, 1],
-      "to": [15, 10, 15],
+      "to": [15, 10, 14.9999],
       "rotation": {"angle": 0, "axis": "y", "origin": [8, 8, 9]},
       "faces": {
         "north": {"uv": [10.75, 8.25, 14.5, 10.75], "rotation": 180, "texture": "#chest"},
         "east": {"uv": [0, 8.25, 3.5, 10.75], "rotation": 180, "texture": "#chest"},
         "south": {"uv": [3.5, 8.25, 7.25, 10.75], "rotation": 180, "texture": "#chest"},
         "up": {"uv": [11, 4.75, 7.25, 8.25], "texture": "#chest"},
-        "down": {"uv": [7.25, 4.75, 3.5, 8.25], "texture": "#chest", "cullface": "down"}
+        "down": {"uv": [7.23, 8.25, 3.5, 4.75], "texture": "#chest", "cullface": "down"}
       }
     }
   ]

--- a/src/main/resources/assets/betterblockentities/models/block/templates/shulker_base_template.json
+++ b/src/main/resources/assets/betterblockentities/models/block/templates/shulker_base_template.json
@@ -10,10 +10,10 @@
       "from": [0, 0, 0],
       "to": [16, 8, 16],
       "faces": {
-        "north": {"uv": [4, 11, 8, 13], "texture": "#shulker", "cullface": "north"},
-        "east": {"uv": [0, 11, 4, 13], "texture": "#shulker", "cullface": "east"},
+        "north": {"uv": [16, 11, 12, 13], "texture": "#shulker", "cullface": "north"},
+        "east": {"uv": [12, 11, 16, 13], "texture": "#shulker", "cullface": "east"},
         "south": {"uv": [12, 11, 16, 13], "texture": "#shulker", "cullface": "south"},
-        "west": {"uv": [8, 11, 12, 13], "texture": "#shulker", "cullface": "west"},
+        "west": {"uv": [12, 11, 16, 13], "texture": "#shulker", "cullface": "west"},
         "down": {"uv": [8, 7, 12, 11], "texture": "#shulker", "cullface": "down"}
       }
     },


### PR DESCRIPTION
Fixes most chest rendering issues:
- Lines on top, front and bottom.
- The inside lid handle texture of single and double chests rendering where they shouldn't.
- Double chests bottom UVs being flipped.
- Small zfighting on the back of double chests.

Also fixes bed feet and shulkerboxes.