### PR TITLE
Fixes a few issues with 26.2

### DIFF
--- a/fabric/src/main/java/betterblockentities/client/render/immediate/overlay/OverlayNodeCollection.java
+++ b/fabric/src/main/java/betterblockentities/client/render/immediate/overlay/OverlayNodeCollection.java
@@ -30,7 +30,7 @@ public class OverlayNodeCollection extends SubmitNodeCollection {
             int outlineColor,
             ModelFeatureRenderer.CrumblingOverlay crumblingOverlay
     ) {
-        if (crumblingOverlay != null) {
+        if (crumblingOverlay != null && renderType.affectsCrumbling()) {
             PoseStack.Pose pose = poseStack.last().copy();
             OverlayNodeStorage.SubmitParameters parameters = this.stack.last();
 

--- a/fabric/src/main/java/betterblockentities/mixin/render/LevelRendererMixin.java
+++ b/fabric/src/main/java/betterblockentities/mixin/render/LevelRendererMixin.java
@@ -2,6 +2,7 @@ package betterblockentities.mixin.render;
 
 /* local */
 import betterblockentities.client.BBE;
+import betterblockentities.client.gui.config.BBEConfig;
 import betterblockentities.client.render.immediate.blockentity.extentions.BlockEntityExt;
 import betterblockentities.client.render.immediate.blockentity.extentions.BlockEntityRenderStateExt;
 import betterblockentities.client.render.immediate.blockentity.misc.RenderingMode;
@@ -56,7 +57,12 @@ public class LevelRendererMixin {
         BlockEntity blockEntity = renderStateExt.bbe$getBlockEntity();
         BlockEntityExt blockEntityExt = (BlockEntityExt)blockEntity;
 
-        if (blockEntityExt.bbe$isSupportedBlockEntity() && blockEntityExt.bbe$getRenderingMode() == RenderingMode.TERRAIN && state.breakProgress != null) {
+        if (blockEntityExt.bbe$isSupportedBlockEntity() &&
+            BBEConfig.OptEnabledTable.ENABLED[blockEntityExt.bbe$getOptKind() & 0xFF] &&
+            blockEntityExt.bbe$getRenderingMode() == RenderingMode.TERRAIN &&
+            blockEntityExt.bbe$isTerrainMeshReady() &&
+            state.breakProgress != null)
+        {
             OverlayRenderer.submitCrumblingOverlay(instance, state, poseStack, camera);
             return;
         }


### PR DESCRIPTION
- Fixes double rendering Banner crumbling/breaking overlay.

- Fixes a bug where, when opts are off and the player is breaking a BE, we would cancel it entirely and only render the breaking overlay.